### PR TITLE
fix wget command, make git-cal executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ on your terminal
 ### Install
 
 Just drop the script anywhere in $PATH
-- with root access: `sudo wget https://raw.github.com/k4rthik/git-cal/master/git-cal -o /usr/local/bin/git-cal`
+- with root access: `sudo wget https://raw.github.com/k4rthik/git-cal/master/git-cal -O /usr/local/bin/git-cal && sudo chmod +x /usr/local/bin/git-cal`
 - `curl https://raw.github.com/k4rthik/git-cal/master/git-cal > ~/bin/git-cal && chmod 0755 !#:3` 
 
 ###TODO


### PR DESCRIPTION
The example wget command was using `-o` which is not writing the downloaded file but all log output there. `-O` (uppercase) is the output file switch.

Also added a `chmod` command to make the file executable, which is required to run it.

From the man file:

```
‘-o logfile’
‘--output-file=logfile’
Log all messages to logfile. The messages are normally reported to standard error.

‘-O file’
‘--output-document=file’
```
