### PR TITLE
Add Makefile.PL to simplify installation.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,0 +1,14 @@
+Installation
+============
+
+With root access:
+
+  perl Makefile.pl
+  make
+  sudo make install
+
+Without root access:
+
+  perl Makefile.pl PREFIX=~/.local
+  make
+  make install

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,0 +1,13 @@
+use 5.006;
+use strict;
+use warnings;
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+  NAME         => 'git-cal',
+  ($ExtUtils::MakeMaker::VERSION >= 6.3002 ? ('LICENSE' => 'mit') : ()),
+  EXE_FILES    => [ 'git-cal', ],
+  PL_FILES     => { },
+  PREREQ_PM    => { },
+  dist         => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
+);

--- a/README.md
+++ b/README.md
@@ -16,16 +16,19 @@ on your terminal
 Just drop the script anywhere in $PATH
 - with root access:
 ```
-sudo wget https://raw.github.com/k4rthik/git-cal/master/git-cal \
--O /usr/local/bin/git-cal && sudo chmod +x /usr/local/bin/git-cal
+perl Makefile.PL
+make
+sudo make install
 ```
 
 - without root access:
 ```
-curl https://raw.github.com/k4rthik/git-cal/master/git-cal > ~/.local/bin/git-cal && chmod 0755 !#:3
+perl Makefile.PL PREFIX=~/.local
+make
+make install
 ```
 
-###TODO
+### TODO
 - Support more statistics like commits per month/week etc
 - May be add a conf file to customize colors
 - Make the code pretty, modularized and easily installable


### PR DESCRIPTION
MakeMaker is a pretty handy tool for generating Makefiles for installing Perl programs. This should make it easier to install git-cal.

After running make and make install, the manpage for git-cal is also automatically generated and installed and the man page can be viewed using:

```
$ man git-cal
```

Great job on the project! This is a really neat tool.
