### PR TITLE
Fixed error message for invalid filename

### DIFF
--- a/git-cal
+++ b/git-cal
@@ -115,7 +115,7 @@ sub git_command {
             $command .= qq{ -- $filepath};
         }
         else {
-            print "fatal: $filepath do not exists\n";
+            print "fatal: $filepath: no such file or directory\n";
             exit(2);
         }
     }


### PR DESCRIPTION
Tweaked the error message for when the filename argument specifies a non-existent file or directory.
