### PR TITLE
Support color print on ascii and unicode mode

### DIFF
--- a/git-cal
+++ b/git-cal
@@ -336,10 +336,10 @@ sub print_grid {
 sub print_block {
     my $index = shift;
     $index = 4 if $index > 4;
-    $_
-      = ( $format eq "ascii" ) ? "${ascii[$index]} "
-      : ( $format eq "unicode" ) ? "${unicode[$index]} "
-      :                            "\e[40;38;5;$colors[$index]m\x{25fc} \e[0m";
+    $_ = "\e[40;38;5;$colors[$index]m" .
+      ( ( $format eq "ascii" ) ? "${ascii[$index]}"
+      : ( $format eq "unicode" ) ? "${unicode[$index]}"
+      :                            "\x{25fc}" ) . " \e[0m";
     print;
 }
 


### PR DESCRIPTION
#18 patch printed non-colored ascii char.

many terminal console support colored char, and basically git-cal required printable colored char terminal(2c6b50b5)
