### PR TITLE
Modify version check for ExtUtils::MakeMaker in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ use ExtUtils::MakeMaker;
 
 WriteMakefile(
     NAME => 'git-cal',
-    ( $ExtUtils::MakeMaker::VERSION >= 6.3002 ? ( 'LICENSE' => 'mit' ) : () ),
+    ( eval ($ExtUtils::MakeMaker::VERSION) >= 6.3002 ? ( 'LICENSE' => 'mit' ) : () ),
     EXE_FILES => [ 'git-cal', ],
     PL_FILES  => {},
     PREREQ_PM => {},


### PR DESCRIPTION
Display the following message when executing 'perl Makefile.PL PREFIX=~/.local',

'Argument "6.55_02" isn't numeric in numeric ge (>=) at Makefile.PL line 6.',

cause $ExtUtils::MakeMaker::VERSION is not numeric.

So I think that you should use 'eval($ExtUtils::MakeMaker::VERSION)' to improve the message.

Thank you.
