### PR TITLE
configure using git config as well as the command line or git aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ on your terminal
 * Each block in the graph corresponds to a day and is shaded with one
   of the 5 possible colors, each representing relative number of commits on that day.
 * Option to choose --ascii or --unicode to denote the same instead of the ANSI colors.
+* Option to use git config to set options.
 
 ### Install
 

--- a/git-cal
+++ b/git-cal
@@ -35,6 +35,8 @@ my @colors = ( 237, 139, 40, 190, 1 );
 my @ascii = ( " ", ".", "o", "O", "0" );
 my @months = qw (Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec);
 
+configure(\$period, \$use_ascii, \$use_ansi, \$use_unicode, \$author);
+
 process();
 
 # 53 X 7 grid
@@ -383,6 +385,36 @@ sub number_of_days {
     return 29;
 }
 
+sub configure {
+    my ($period, $ascii, $ansi, $unicode, $author) = @_;
+    my @wanted;
+    push @wanted, 'format' if (not grep { defined $$_ } ($ascii, $ansi, $unicode));
+    push @wanted, 'period' if (not defined $$period);
+    push @wanted, 'author' if (not defined $$author);
+    if (@wanted) {
+	my $git_command = "git config --get-regexp 'calendar\.*'";
+	my @parts       = split(/\s/, qx/$git_command/);
+	if(@parts) {
+	    my %config;
+	    while(my ($key, $value) = splice(@parts, 0, 2)) {
+		$key =~ s/calendar\.//;
+		$config{$key} = $value;
+	    }
+	    local @ARGV = (map  { ( "-$_" => $config{$_} ) } 
+			   grep { exists $config{$_}       } @wanted);
+	    GetOptions(
+		'period=n'  => $period,
+		'format=s'  => sub {
+		    if    ($_[1] eq 'ascii')   { $$ascii   ||= 1; }
+		    elsif ($_[1] eq 'ansi')    { $$ansi    ||= 1; }
+		    elsif ($_[1] eq 'unicode') { $$unicode ||= 1; }
+		},
+		'author=s'  => $author
+		);
+	}
+    }
+}
+
 __END__
 
 =head1 NAME
@@ -454,6 +486,20 @@ Print this message.
 =head2 ADDITIONAL OPTIONS
 
 <filepath> to view the logs of a particular file or directory
+
+=head2 USING GIT CONFIG
+
+git-cal uses the git config tool to store configuration on disk.  Similar keys are used to 
+those listed above with the notable exception being the bundling of ascii, ansi and unicode
+into a "format" key. Examples of the three supported keys are below.
+
+ git config --global calendar.format ascii
+
+ git config --global calendar.period 5
+
+ git config --global calendar.author karthik
+
+A command line supplied option will override the matching option set using this method.
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Although it is possible to use a git aliases `git config --global alias.ansical 'cal --ansi'` to persistently configure behaviour of git-cal, this PR adds the ability to store the settings in a "calendar" stanza. Setting via the command line thus: `git config --global calendar.format ansi`

The full list in a `~/.gitconfig` might look like.

``` ini
[calendar]
    format = ansi
    period = 5
    author = karthik
```

I look forward to your thoughts on this.
