### PR TITLE
Use /usr/bin/env to find perl

### DIFF
--- a/git-cal
+++ b/git-cal
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;


### PR DESCRIPTION
FreeBSD doesn't have /usr/bin/perl.  Let /usr/bin/env to find perl